### PR TITLE
mocking supports data namespaces within the global namespace

### DIFF
--- a/lib/mock.q
+++ b/lib/mock.q
@@ -9,6 +9,8 @@ mock:{[name;newVal];
  name:$[1 = c: count ` vs name;
   / Create fully qualified name if given a local one
   ` sv .tst.context,name;
+  not ` ~ first ` vs name;
+  ` sv .tst.context,name;
   (2 = c) and ` ~ first ` vs name;
   '"Can't mock top-level namespaces!";
   name];

--- a/test/test_mock.q
+++ b/test/test_mock.q
@@ -23,4 +23,14 @@
  should["refuse to mock a top level namespace"]{
   mustthrow[()] { `.tst mock ` };
   };
+ should["support data namespaces within the global namespace"]{
+  `..ns.foo set 0;
+  `ns.foo mock 1;
+  `ns.bar mock 2;
+  ns.foo musteq 1;
+  .tst.restore[];
+  (get `..ns.foo) musteq 0;
+  mustthrow["..ns.bar"] {get `..ns.bar};
+  delete ns from `.;
+  };
  };


### PR DESCRIPTION
fixes #4 